### PR TITLE
Variable edges

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"github.com/mitchellh/go-homedir"
+	"github.com/pulcy/robin/service"
+	"github.com/pulcy/robin/service/backend"
 )
 
 const (
@@ -45,6 +47,14 @@ const (
 	defaultMetricsHost      = "0.0.0.0"
 	defaultMetricsPort      = 8055
 	defaultPrivateStatsPort = 7089
+)
+
+var (
+	etcdBackendConfig = backend.BackendConfig{
+		PublicEdgePort:      service.PublicHttpPort,
+		PrivateHttpEdgePort: service.PrivateHttpPort,
+		PrivateTcpEdgePort:  service.PrivateTcpSslPort,
+	}
 )
 
 func defaultPrivateKeyPath() string {

--- a/defaults.go
+++ b/defaults.go
@@ -30,6 +30,7 @@ const (
 	defaultSslCertsFolder    = "/certs/"
 	defaultForceSsl          = false
 	defaultPrivateHost       = ""
+	defaultPublicHost        = ""
 	defaultPrivateTcpSslCert = ""
 	defaultLogLevel          = "info"
 )

--- a/deps/github.com/pulcy/robin-api/frontend.go
+++ b/deps/github.com/pulcy/robin-api/frontend.go
@@ -29,7 +29,8 @@ type FrontendSelectorRecord struct {
 	Domain       string        `json:"domain,omitempty"`
 	PathPrefix   string        `json:"path-prefix,omitempty"`
 	SslCert      string        `json:"ssl-cert,omitempty"`
-	Port         int           `json:"port,omitempty"`
+	ServicePort  int           `json:"port,omitempty"`
+	FrontendPort int           `json:"frontend-port,omitempty"`
 	Private      bool          `json:"private,omitempty"`
 	Users        []UserRecord  `json:"users,omitempty"`
 	RewriteRules []RewriteRule `json:"rewrite-rules,omitempty"`

--- a/run.go
+++ b/run.go
@@ -55,6 +55,7 @@ var (
 		sslCertsFolder    string
 		forceSsl          bool
 		privateHost       string
+		publicHost        string
 		privateTcpSslCert string
 
 		// acme
@@ -91,6 +92,7 @@ func init() {
 	cmdRun.Flags().StringVar(&runArgs.sslCertsFolder, "ssl-certs", defaultSslCertsFolder, "Folder containing SSL certificate")
 	cmdRun.Flags().BoolVar(&runArgs.forceSsl, "force-ssl", defaultForceSsl, "Redirect HTTP to HTTPS")
 	cmdRun.Flags().StringVar(&runArgs.privateHost, "private-host", defaultPrivateHost, "IP address of private network")
+	cmdRun.Flags().StringVar(&runArgs.publicHost, "public-host", defaultPublicHost, "IP address of public network")
 	cmdRun.Flags().StringVar(&runArgs.privateTcpSslCert, "private-ssl-cert", defaultPrivateTcpSslCert, "Filename of SSL certificate for private TCP connections (located in ssl-certs)")
 	// acme
 	cmdRun.Flags().IntVar(&runArgs.acmeHttpPort, "acme-http-port", defaultAcmeHttpPort, "Port to listen for ACME HTTP challenges on (internally)")

--- a/run.go
+++ b/run.go
@@ -134,7 +134,7 @@ func cmdRunRun(cmd *cobra.Command, args []string) {
 	logging.SetLevel(level, cmdMain.Use)
 
 	// Prepare backend
-	backend, err := backend.NewEtcdBackend(log, etcdUrl)
+	backend, err := backend.NewEtcdBackend(etcdBackendConfig, log, etcdUrl)
 	if err != nil {
 		Exitf("Failed to backend: %#v", err)
 	}

--- a/run.go
+++ b/run.go
@@ -57,6 +57,8 @@ var (
 		privateHost       string
 		publicHost        string
 		privateTcpSslCert string
+		excludePublic     bool
+		excludePrivate    bool
 
 		// acme
 		acmeHttpPort       int
@@ -94,6 +96,8 @@ func init() {
 	cmdRun.Flags().StringVar(&runArgs.privateHost, "private-host", defaultPrivateHost, "IP address of private network")
 	cmdRun.Flags().StringVar(&runArgs.publicHost, "public-host", defaultPublicHost, "IP address of public network")
 	cmdRun.Flags().StringVar(&runArgs.privateTcpSslCert, "private-ssl-cert", defaultPrivateTcpSslCert, "Filename of SSL certificate for private TCP connections (located in ssl-certs)")
+	cmdRun.Flags().BoolVar(&runArgs.excludePrivate, "exclude-private", false, "Exclude private frontends")
+	cmdRun.Flags().BoolVar(&runArgs.excludePublic, "exclude-public", false, "Exclude public frontends")
 	// acme
 	cmdRun.Flags().IntVar(&runArgs.acmeHttpPort, "acme-http-port", defaultAcmeHttpPort, "Port to listen for ACME HTTP challenges on (internally)")
 	cmdRun.Flags().StringVar(&runArgs.acmeEmail, "acme-email", defaultAcmeEmail, "Email account for ACME server")
@@ -192,6 +196,8 @@ func cmdRunRun(cmd *cobra.Command, args []string) {
 		PrivateHost:       runArgs.privateHost,
 		PrivateTcpSslCert: runArgs.privateTcpSslCert,
 		PrivateStatsPort:  runArgs.privateStatsPort,
+		ExcludePrivate:    runArgs.excludePrivate,
+		ExcludePublic:     runArgs.excludePublic,
 	}, service.ServiceDependencies{
 		Logger:      log,
 		Backend:     backend,

--- a/service/acme/service.go
+++ b/service/acme/service.go
@@ -173,11 +173,8 @@ func (s *acmeService) Extend(services backend.ServiceRegistrations) (backend.Ser
 	allDomains := []string{}
 	updatedServices := backend.ServiceRegistrations{}
 	for _, sr := range services {
-		if !sr.Public {
-			continue
-		}
 		for selIndex, sel := range sr.Selectors {
-			if sel.SslCertName != "" || sel.Domain == "" {
+			if !sr.Public || sel.SslCertName != "" || sel.Domain == "" {
 				continue
 			}
 			// Domain needs a certificate, try cache first

--- a/service/backend/backend.go
+++ b/service/backend/backend.go
@@ -42,6 +42,13 @@ type ServiceRegistration struct {
 	Backup          bool             // If set all instances are backup only servers for their selectors
 }
 
+func (sr ServiceRegistration) Normalize() ServiceRegistration {
+	if sr.Mode == "" {
+		sr.Mode = "http"
+	}
+	return sr
+}
+
 func (sr ServiceRegistration) FullString() string {
 	return fmt.Sprintf("%s-%d-%s-%s-%s-%s-%s-%v-%v",
 		sr.ServiceName,

--- a/service/backend/etcd_backend.go
+++ b/service/backend/etcd_backend.go
@@ -165,6 +165,7 @@ func (eb *etcdBackend) mergeTrees(services []regapi.Service, frontends []api.Fro
 					Port: si.Port,
 				})
 			}
+			eb.Logger.Debugf("Created service '%s' edge-port=%d, public=%v, mode=%s", serviceName, edgePort, public, mode)
 			return service
 		}
 		servicesByEdge := make(map[string]*ServiceRegistration)
@@ -197,8 +198,8 @@ func (eb *etcdBackend) mergeTrees(services []regapi.Service, frontends []api.Fro
 		}
 
 		for _, fr := range frontends {
-			extService := fmt.Sprintf("%s-%d", fr.Service, servicePort)
-			if serviceName != fr.Service && serviceName != extService {
+			frExtService := fmt.Sprintf("%s-%d", fr.Service, servicePort)
+			if serviceName != fr.Service && serviceName != frExtService {
 				continue
 			}
 			for _, sel := range fr.Selectors {
@@ -238,14 +239,15 @@ func (eb *etcdBackend) mergeTrees(services []regapi.Service, frontends []api.Fro
 					})
 				}
 				if !service.Selectors.Contains(srSel) {
+					eb.Logger.Debugf("Selector %s added to service %s:%d", srSel.FullString(), serviceName, servicePort)
 					service.Selectors = append(service.Selectors, srSel)
+				} else {
+					eb.Logger.Debugf("Selector %s already found in service %s:%d", srSel.FullString(), serviceName, servicePort)
 				}
 			}
 		}
 		for _, service := range servicesByEdge {
-			if len(service.Selectors) > 0 {
-				result = append(result, *service)
-			}
+			result = append(result, *service)
 		}
 	}
 	return result, nil

--- a/service/backend/etcd_backend.go
+++ b/service/backend/etcd_backend.go
@@ -151,8 +151,8 @@ func (eb *etcdBackend) mergeTrees(services []regapi.Service, frontends []api.Fro
 		serviceName := s.ServiceName
 		servicePort := s.ServicePort
 
-		createServiceRegistration := func(edgePort int, public bool, mode string) ServiceRegistration {
-			service := ServiceRegistration{
+		createServiceRegistration := func(edgePort int, public bool, mode string) *ServiceRegistration {
+			service := &ServiceRegistration{
 				ServiceName: serviceName,
 				ServicePort: servicePort,
 				EdgePort:    edgePort,
@@ -186,8 +186,7 @@ func (eb *etcdBackend) mergeTrees(services []regapi.Service, frontends []api.Fro
 			key := fmt.Sprintf("%d-%v", edgePort, private)
 			sr, ok := servicesByEdge[key]
 			if !ok {
-				newSR := createServiceRegistration(edgePort, !private, mode)
-				sr = &newSR
+				sr = createServiceRegistration(edgePort, !private, mode)
 				servicesByEdge[key] = sr
 			} else {
 				if sr.Mode != mode {
@@ -245,9 +244,6 @@ func (eb *etcdBackend) mergeTrees(services []regapi.Service, frontends []api.Fro
 		}
 		for _, service := range servicesByEdge {
 			if len(service.Selectors) > 0 {
-				if service.Mode == "" {
-					service.Mode = "http"
-				}
 				result = append(result, *service)
 			}
 		}

--- a/service/config_builder.go
+++ b/service/config_builder.go
@@ -159,6 +159,9 @@ func (s *Service) renderConfig(services backend.ServiceRegistrations) (string, e
 	var frontends frontendList
 	frontendMap := make(map[string]frontend)
 	collectFrontend := func(index, edgePort int, public bool, mode string) {
+		if (public && s.ExcludePublic) || (!public && s.ExcludePrivate) {
+			return // Exclude
+		}
 		f := frontend{
 			index:  index,
 			Port:   edgePort,

--- a/service/config_builder.go
+++ b/service/config_builder.go
@@ -24,6 +24,13 @@ import (
 	"github.com/pulcy/robin/service/backend"
 )
 
+const (
+	PublicHttpPort    = 80
+	PublicHttpsPort   = 443
+	PrivateHttpPort   = 81
+	PrivateTcpSslPort = 82
+)
+
 var (
 	globalOptions = []string{
 		//"log global",
@@ -63,9 +70,27 @@ type useBlock struct {
 	RewriteRules      []backend.RewriteRule
 }
 
-type selection struct {
-	Private bool
-	Http    bool
+type frontend struct {
+	Port   int
+	Public bool
+	Mode   string
+}
+
+func (f frontend) Name() string {
+	if f.Public {
+		return fmt.Sprintf("public_%s_in_%d", f.Mode, f.Port)
+	}
+	return fmt.Sprintf("private_%s_in_%d", f.Mode, f.Port)
+}
+
+// IsHTTP returns true if Mode == "http"
+func (f frontend) IsHTTP() bool {
+	return f.Mode == "http"
+}
+
+// IsTCP returns true if Mode == "tcp"
+func (f frontend) IsTCP() bool {
+	return f.Mode == "tcp"
 }
 
 // renderConfig creates a new haproxy configuration content.
@@ -91,91 +116,83 @@ func (s *Service) renderConfig(services backend.ServiceRegistrations) (string, e
 	certs := []string{}
 	certsSet := make(map[string]struct{})
 	for _, sr := range services {
-		for _, sel := range sr.Selectors {
-			if !sel.Private && sel.IsSecure() {
-				certPath := sel.TmpSslCertPath
-				if certPath == "" {
-					certPath = filepath.Join(s.SslCertsFolder, sel.SslCertName)
-				}
-				if _, ok := certsSet[certPath]; !ok {
-					crt := fmt.Sprintf("crt %s", certPath)
-					certs = append(certs, crt)
-					certsSet[certPath] = struct{}{}
+		if sr.Public {
+			for _, sel := range sr.Selectors {
+				if sel.IsSecure() {
+					certPath := sel.TmpSslCertPath
+					if certPath == "" {
+						certPath = filepath.Join(s.SslCertsFolder, sel.SslCertName)
+					}
+					if _, ok := certsSet[certPath]; !ok {
+						crt := fmt.Sprintf("crt %s", certPath)
+						certs = append(certs, crt)
+						certsSet[certPath] = struct{}{}
+					}
 				}
 			}
 		}
 	}
 
-	// Create config for all registrations
-	publicHttpFrontEndSection := c.Section("frontend http-in")
-	publicHttpFrontEndSection.Add("bind *:80")
-	var publicHttpsFrontEndSection *haproxy.Section
-	publicFrontEndSections := []*haproxy.Section{publicHttpFrontEndSection}
-	if len(certs) > 0 {
-		publicHttpsFrontEndSection = c.Section("frontend https-in")
-		publicFrontEndSections = append(publicFrontEndSections, publicHttpsFrontEndSection)
-		publicHttpsFrontEndSection.Add(
-			fmt.Sprintf("bind *:443 ssl %s no-sslv3", strings.Join(certs, " ")),
-		)
-		if s.ForceSsl {
-			publicHttpFrontEndSection.Add("redirect scheme https if !{ ssl_fc }")
+	// Collect frontends
+	frontends := make(map[string]frontend)
+	collectFrontend := func(edgePort int, public bool, mode string) {
+		f := frontend{
+			Port:   edgePort,
+			Public: public,
+			Mode:   mode,
 		}
+		frontends[f.Name()] = f
 	}
-	for _, section := range publicFrontEndSections {
-		section.Add(
-			"mode http",
-			"option forwardfor",
-			//"option httplog",
-			"reqadd X-Forwarded-Port:\\ %[dst_port]",
-			"reqadd X-Forwarded-Proto:\\ https if { ssl_fc }",
-			"default_backend fallback",
-		)
+	collectFrontend(PublicHttpPort, true, "http")   // Always create a public HTTP frontend
+	collectFrontend(PrivateHttpPort, false, "http") // Always create a private HTTP frontend
+	for _, sr := range services {
+		collectFrontend(sr.EdgePort, sr.Public, sr.Mode)
 	}
+
+	// Create all frontends
 	aclNameGen := NewNameGenerator("acl")
 	backends := make(map[string]backendConfig)
-	// Create acls
-	publicFrontEndSelection := selection{Private: false, Http: true}
-	useBlocks, backends := createAcls(publicFrontEndSections, services, publicFrontEndSelection, aclNameGen, backends)
-	// Create link to backends
-	createUseBackends(publicHttpFrontEndSection, useBlocks, publicFrontEndSelection, (publicHttpsFrontEndSection != nil))
-	if publicHttpsFrontEndSection != nil {
-		createUseBackends(publicHttpsFrontEndSection, useBlocks, publicFrontEndSelection, false)
-	}
-
-	// Create config for private HTTP services
-	privateFrontEndSection := c.Section("frontend http-in-private")
-	privateFrontEndSection.Add("bind *:81")
-	privateFrontEndSection.Add(
-		"mode http",
-		"option forwardfor",
-		//"option httplog",
-		"reqadd X-Forwarded-Port:\\ %[dst_port]",
-		"reqadd X-Forwarded-Proto:\\ https if { ssl_fc }",
-		"default_backend fallback",
-	)
-	// Create acls
-	privateFrontEndSelection := selection{Private: true, Http: true}
-	useBlocks, backends = createAcls([]*haproxy.Section{privateFrontEndSection}, services, privateFrontEndSelection, aclNameGen, backends)
-	// Create link to backend
-	createUseBackends(privateFrontEndSection, useBlocks, privateFrontEndSelection, false)
-
-	// Create config for private TCP services
-	if s.PrivateTcpSslCert != "" {
-		privateTcpFrontEndSection := c.Section("frontend tcp-in-private")
-		privateTcpSsl := fmt.Sprintf("ssl generate-certificates ca-sign-file %s crt %s no-sslv3",
-			filepath.Join(s.SslCertsFolder, s.PrivateTcpSslCert),
-			filepath.Join(s.SslCertsFolder, s.PrivateTcpSslCert),
-		)
-		privateTcpFrontEndSection.Add("bind *:82 " + privateTcpSsl)
-		privateTcpFrontEndSection.Add(
-			"mode tcp",
-			"default_backend fallback",
-		)
+	for _, frontend := range frontends {
+		frontendSection := c.Section(fmt.Sprintf("frontend %s", frontend.Name()))
+		bind := fmt.Sprintf("bind *:%d", frontend.Port) // TODO bind interface depending on frontend.Public
+		if !frontend.Public && frontend.IsTCP() && frontend.Port == PrivateTcpSslPort && s.PrivateTcpSslCert != "" {
+			bind = fmt.Sprintf("%s ssl generate-certificates ca-sign-file %s crt %s no-sslv3",
+				bind,
+				filepath.Join(s.SslCertsFolder, s.PrivateTcpSslCert),
+				filepath.Join(s.SslCertsFolder, s.PrivateTcpSslCert),
+			)
+		}
+		frontendSection.Add(bind)
+		var secureFrontendSection *haproxy.Section
+		frontendSections := []*haproxy.Section{frontendSection}
+		if frontend.Public && frontend.Port == PublicHttpPort && frontend.IsHTTP() && len(certs) > 0 {
+			secureFrontendSection = c.Section(fmt.Sprintf("frontend secure-%s", frontend.Name()))
+			frontendSections = append(frontendSections, secureFrontendSection)
+			secureFrontendSection.Add(fmt.Sprintf("bind *:%d ssl %s no-sslv3", PublicHttpsPort, strings.Join(certs, " ")))
+			if s.ForceSsl {
+				secureFrontendSection.Add("redirect scheme https if !{ ssl_fc }")
+			}
+		}
+		for _, section := range frontendSections {
+			section.Add(fmt.Sprintf("mode %s", frontend.Mode))
+			if frontend.IsHTTP() {
+				section.Add(
+					"option forwardfor",
+					//"option httplog",
+					"reqadd X-Forwarded-Port:\\ %[dst_port]",
+					"reqadd X-Forwarded-Proto:\\ https if { ssl_fc }",
+				)
+			}
+			section.Add("default_backend fallback")
+		}
 		// Create acls
-		privateTcpFrontEndSelection := selection{Private: true, Http: false}
-		useBlocks, backends = createAcls([]*haproxy.Section{privateTcpFrontEndSection}, services, privateTcpFrontEndSelection, aclNameGen, backends)
-		// Create link to backend
-		createUseBackends(privateTcpFrontEndSection, useBlocks, privateTcpFrontEndSelection, false)
+		var useBlocks []useBlock
+		useBlocks, backends = createAcls(frontendSections, services, frontend, aclNameGen, backends)
+		// Create link to backends
+		createUseBackends(frontendSection, useBlocks, frontend, (secureFrontendSection != nil))
+		if secureFrontendSection != nil {
+			createUseBackends(secureFrontendSection, useBlocks, frontend, false)
+		}
 	}
 
 	// Create stats section
@@ -302,23 +319,24 @@ func createAclRules(sel backend.ServiceSelector, isTcp bool) []string {
 	if sel.PathPrefix != "" {
 		result = append(result, fmt.Sprintf("path_beg %s", sel.PathPrefix))
 	}
+	if len(result) == 0 && isTcp {
+		result = append(result, "true")
+	}
 	return result
 }
 
 // creteAcls create `acl` rules for the given services and adds them
 // to the given section
-func createAcls(sections []*haproxy.Section, services backend.ServiceRegistrations, selection selection, ng *nameGenerator, backends map[string]backendConfig) ([]useBlock, map[string]backendConfig) {
+func createAcls(sections []*haproxy.Section, services backend.ServiceRegistrations, selection frontend, ng *nameGenerator, backends map[string]backendConfig) ([]useBlock, map[string]backendConfig) {
 	pairs := selectorServicePairs{}
 	for _, sr := range services {
-		if sr.IsHttp() == selection.Http {
+		if sr.IsHttp() == selection.IsHTTP() && sr.Public == selection.Public {
 			for selIndex, sel := range sr.Selectors {
-				if sel.Private == selection.Private {
-					pairs = append(pairs, selectorServicePair{
-						Selector:      sel,
-						SelectorIndex: selIndex,
-						Service:       sr,
-					})
-				}
+				pairs = append(pairs, selectorServicePair{
+					Selector:      sel,
+					SelectorIndex: selIndex,
+					Service:       sr,
+				})
 			}
 		}
 	}
@@ -378,7 +396,7 @@ func createAcls(sections []*haproxy.Section, services backend.ServiceRegistratio
 
 // createUseBackends creates a `use_backend` rules for the given input
 // and adds it to the given section
-func createUseBackends(section *haproxy.Section, useBlocks []useBlock, selection selection, redirectHttps bool) {
+func createUseBackends(section *haproxy.Section, useBlocks []useBlock, selection frontend, redirectHttps bool) {
 	for _, useBlock := range useBlocks {
 		if len(useBlock.AclNames) == 0 {
 			continue
@@ -422,8 +440,8 @@ func createUseBackends(section *haproxy.Section, useBlocks []useBlock, selection
 
 // generateBackendName creates a valid name for the backend of this registration
 // in haproxy.
-func generateBackendName(sr backend.ServiceRegistration, selection selection) string {
-	return fmt.Sprintf("backend_%s_%d_%s", cleanName(sr.ServiceName), sr.ServicePort, visibilityPostfix(selection))
+func generateBackendName(sr backend.ServiceRegistration, selection frontend) string {
+	return fmt.Sprintf("backend_%s_%d_%s", cleanName(sr.ServiceName), sr.ServicePort, selection.Name())
 }
 
 // userListName creates a valid name for the userlist of this registration
@@ -437,16 +455,16 @@ func cleanName(s string) string {
 	return s // TODO
 }
 
-func visibilityPostfix(selection selection) string {
-	if selection.Private {
-		if selection.Http {
+/*func visibilityPostfix_(selection frontend) string {
+	if !selection.Public {
+		if selection.IsHttp() {
 			return "private"
 		} else {
 			return "private-tcp"
 		}
 	}
 	return "public"
-}
+}*/
 
 type selectorServicePair struct {
 	Selector      backend.ServiceSelector

--- a/service/config_builder.go
+++ b/service/config_builder.go
@@ -361,7 +361,7 @@ func createAclRules(sel backend.ServiceSelector, isTcp bool) []string {
 		result = append(result, fmt.Sprintf("path_beg %s", sel.PathPrefix))
 	}
 	if len(result) == 0 && isTcp {
-		result = append(result, "true")
+		result = append(result, "always_true")
 	}
 	return result
 }

--- a/service/config_builder_test.go
+++ b/service/config_builder_test.go
@@ -21,10 +21,23 @@ var (
 			PrivateHost: "10.0.0.1",
 		},
 	}
+	privateOnlyService = Service{
+		ServiceConfig: ServiceConfig{
+			PrivateHost:   "10.0.0.2",
+			ExcludePublic: true,
+		},
+	}
+	publicOnlyService = Service{
+		ServiceConfig: ServiceConfig{
+			PrivateHost:    "8.8.8.8",
+			ExcludePrivate: true,
+		},
+	}
 	privateStatsService = Service{
 		ServiceConfig: ServiceConfig{
 			PublicHost:       "7.7.7.7",
 			PrivateStatsPort: 1234,
+			ExcludePublic:    true,
 		},
 	}
 	configTests = []configTest{
@@ -39,7 +52,7 @@ var (
 			ResultPath: "./fixtures/empty-private-stats.txt",
 		},
 		configTest{
-			Service: testService,
+			Service: publicOnlyService,
 			Services: backend.ServiceRegistrations{
 				backend.ServiceRegistration{
 					ServiceName: "simple",
@@ -239,7 +252,7 @@ var (
 			ResultPath: "./fixtures/backup_services.txt",
 		},
 		configTest{
-			Service: testService,
+			Service: privateOnlyService,
 			Services: backend.ServiceRegistrations{
 				backend.ServiceRegistration{
 					ServiceName: "private1",

--- a/service/config_builder_test.go
+++ b/service/config_builder_test.go
@@ -16,9 +16,14 @@ type configTest struct {
 }
 
 var (
-	testService         = Service{}
+	testService = Service{
+		ServiceConfig: ServiceConfig{
+			PrivateHost: "10.0.0.1",
+		},
+	}
 	privateStatsService = Service{
 		ServiceConfig: ServiceConfig{
+			PublicHost:       "7.7.7.7",
 			PrivateStatsPort: 1234,
 		},
 	}

--- a/service/config_builder_test.go
+++ b/service/config_builder_test.go
@@ -39,6 +39,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "simple",
 					ServicePort: 80,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
@@ -59,6 +61,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "simple12",
 					ServicePort: 80,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
@@ -73,6 +77,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "simple2",
 					ServicePort: 5000,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 7001},
 					},
@@ -86,6 +92,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "simple3",
 					ServicePort: 5000,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 7001},
 					},
@@ -106,6 +114,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "service1",
 					ServicePort: 80,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
@@ -120,6 +130,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "service2",
 					ServicePort: 5000,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 7001},
 						backend.ServiceInstance{IP: "192.168.23.1", Port: 7005},
@@ -135,6 +147,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "service3_prefix",
 					ServicePort: 4700,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 7001},
 					},
@@ -149,6 +163,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "service4_small_prefix_only",
 					ServicePort: 4700,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 9001},
 					},
@@ -162,6 +178,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "service4_large_prefix_only",
 					ServicePort: 6004,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.33", Port: 19001},
 					},
@@ -181,6 +199,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "master",
 					ServicePort: 80,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
@@ -196,6 +216,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "slave",
 					ServicePort: 5000,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.35", Port: 7001},
 						backend.ServiceInstance{IP: "192.168.35.37", Port: 7007},
@@ -217,14 +239,15 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "private1",
 					ServicePort: 80,
+					Public:      false,
+					EdgePort:    PrivateHttpPort,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
 					},
 					Selectors: backend.ServiceSelectors{
 						backend.ServiceSelector{
-							Domain:  "service1.private",
-							Private: true,
+							Domain: "service1.private",
 						},
 					},
 					Mode: "http",
@@ -238,6 +261,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "service1",
 					ServicePort: 80,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
@@ -251,13 +276,25 @@ var (
 							Domain:     "nested.foo.com",
 							PathPrefix: "/foo",
 						},
+					},
+					Mode: "http",
+				},
+				backend.ServiceRegistration{
+					ServiceName: "service1",
+					ServicePort: 80,
+					EdgePort:    PrivateHttpPort,
+					Public:      false,
+					Instances: backend.ServiceInstances{
+						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
+						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
+						backend.ServiceInstance{IP: "192.168.23.32", Port: 2346},
+					},
+					Selectors: backend.ServiceSelectors{
 						backend.ServiceSelector{
-							Domain:  "foo.com.private",
-							Private: true,
+							Domain: "foo.com.private",
 						},
 						backend.ServiceSelector{
-							Domain:  "service1.private",
-							Private: true,
+							Domain: "service1.private",
 						},
 					},
 					Mode: "http",
@@ -271,6 +308,8 @@ var (
 				backend.ServiceRegistration{
 					ServiceName: "sticky1",
 					ServicePort: 80,
+					EdgePort:    PublicHttpPort,
+					Public:      true,
 					Instances: backend.ServiceInstances{
 						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
 						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
@@ -286,6 +325,28 @@ var (
 				},
 			},
 			ResultPath: "./fixtures/sticky_service.txt",
+		},
+		configTest{
+			Service: testService,
+			Services: backend.ServiceRegistrations{
+				backend.ServiceRegistration{
+					ServiceName: "gogs",
+					ServicePort: 22,
+					EdgePort:    8022,
+					Public:      true,
+					Instances: backend.ServiceInstances{
+						backend.ServiceInstance{IP: "192.168.35.2", Port: 2345},
+						backend.ServiceInstance{IP: "192.168.35.3", Port: 2346},
+						backend.ServiceInstance{IP: "192.168.23.32", Port: 2346},
+					},
+					Selectors: backend.ServiceSelectors{
+						backend.ServiceSelector{},
+					},
+					Sticky: true,
+					Mode:   "tcp",
+				},
+			},
+			ResultPath: "./fixtures/ssh_gogs.txt",
 		},
 	}
 )

--- a/service/fixtures/backup_services.txt
+++ b/service/fixtures/backup_services.txt
@@ -28,7 +28,7 @@ frontend public_http_in_80
     use_backend backend_master_80_public_http_in_80 if acl1
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/backup_services.txt
+++ b/service/fixtures/backup_services.txt
@@ -17,7 +17,7 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend http-in
+frontend public_http_in_80
     bind *:80
     mode http
     option forwardfor
@@ -25,9 +25,9 @@ frontend http-in
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
     acl acl1 hdr_dom(host) -i foo.com
-    use_backend backend_master_80_public if acl1
+    use_backend backend_master_80_public_http_in_80 if acl1
 
-frontend http-in-private
+frontend private_http_in_81
     bind *:81
     mode http
     option forwardfor
@@ -35,7 +35,7 @@ frontend http-in-private
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
 
-backend backend_master_80_public
+backend backend_master_80_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000

--- a/service/fixtures/empty-private-stats.txt
+++ b/service/fixtures/empty-private-stats.txt
@@ -17,14 +17,6 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend public_http_in_80
-    bind 7.7.7.7:80
-    mode http
-    option forwardfor
-    reqadd X-Forwarded-Port:\ %[dst_port]
-    reqadd X-Forwarded-Proto:\ https if { ssl_fc }
-    default_backend fallback
-
 frontend private_http_in_81
     bind *:81
     mode http

--- a/service/fixtures/empty-private-stats.txt
+++ b/service/fixtures/empty-private-stats.txt
@@ -17,7 +17,7 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend http-in
+frontend public_http_in_80
     bind *:80
     mode http
     option forwardfor
@@ -25,7 +25,7 @@ frontend http-in
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
 
-frontend http-in-private
+frontend private_http_in_81
     bind *:81
     mode http
     option forwardfor

--- a/service/fixtures/empty-private-stats.txt
+++ b/service/fixtures/empty-private-stats.txt
@@ -18,7 +18,7 @@ defaults
     errorfile 504 /app/errors/504.http
 
 frontend public_http_in_80
-    bind *:80
+    bind 7.7.7.7:80
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/empty.txt
+++ b/service/fixtures/empty.txt
@@ -17,7 +17,7 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend http-in
+frontend public_http_in_80
     bind *:80
     mode http
     option forwardfor
@@ -25,7 +25,7 @@ frontend http-in
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
 
-frontend http-in-private
+frontend private_http_in_81
     bind *:81
     mode http
     option forwardfor

--- a/service/fixtures/empty.txt
+++ b/service/fixtures/empty.txt
@@ -26,7 +26,7 @@ frontend public_http_in_80
     default_backend fallback
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/many_frontends_service.txt
+++ b/service/fixtures/many_frontends_service.txt
@@ -31,7 +31,7 @@ frontend public_http_in_80
     use_backend backend_service1_80_public_http_in_80 if acl3
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/many_frontends_service.txt
+++ b/service/fixtures/many_frontends_service.txt
@@ -17,7 +17,7 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend http-in
+frontend public_http_in_80
     bind *:80
     mode http
     option forwardfor
@@ -27,10 +27,10 @@ frontend http-in
     acl acl1 hdr_dom(host) -i nested.foo.com
     acl acl2 path_beg /foo
     acl acl3 hdr_dom(host) -i foo.com
-    use_backend backend_service1_80_public if acl1 acl2
-    use_backend backend_service1_80_public if acl3
+    use_backend backend_service1_80_public_http_in_80 if acl1 acl2
+    use_backend backend_service1_80_public_http_in_80 if acl3
 
-frontend http-in-private
+frontend private_http_in_81
     bind *:81
     mode http
     option forwardfor
@@ -39,10 +39,10 @@ frontend http-in-private
     default_backend fallback
     acl acl4 hdr_dom(host) -i foo.com.private
     acl acl5 hdr_dom(host) -i service1.private
-    use_backend backend_service1_80_private if acl4
-    use_backend backend_service1_80_private if acl5
+    use_backend backend_service1_80_private_http_in_81 if acl4
+    use_backend backend_service1_80_private_http_in_81 if acl5
 
-backend backend_service1_80_private
+backend backend_service1_80_private_http_in_81
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000
@@ -53,7 +53,7 @@ backend backend_service1_80_private
     server s1-192_168_35_3-2346 192.168.35.3:2346 
     server s2-192_168_23_32-2346 192.168.23.32:2346 
 
-backend backend_service1_80_public
+backend backend_service1_80_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000

--- a/service/fixtures/private_service.txt
+++ b/service/fixtures/private_service.txt
@@ -17,7 +17,7 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend http-in
+frontend public_http_in_80
     bind *:80
     mode http
     option forwardfor
@@ -25,7 +25,7 @@ frontend http-in
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
 
-frontend http-in-private
+frontend private_http_in_81
     bind *:81
     mode http
     option forwardfor
@@ -33,9 +33,9 @@ frontend http-in-private
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
     acl acl1 hdr_dom(host) -i service1.private
-    use_backend backend_private1_80_private if acl1
+    use_backend backend_private1_80_private_http_in_81 if acl1
 
-backend backend_private1_80_private
+backend backend_private1_80_private_http_in_81
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000

--- a/service/fixtures/private_service.txt
+++ b/service/fixtures/private_service.txt
@@ -26,7 +26,7 @@ frontend public_http_in_80
     default_backend fallback
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/private_service.txt
+++ b/service/fixtures/private_service.txt
@@ -17,16 +17,8 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend public_http_in_80
-    bind *:80
-    mode http
-    option forwardfor
-    reqadd X-Forwarded-Port:\ %[dst_port]
-    reqadd X-Forwarded-Proto:\ https if { ssl_fc }
-    default_backend fallback
-
 frontend private_http_in_81
-    bind 10.0.0.1:81
+    bind 10.0.0.2:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/same_domain_services.txt
+++ b/service/fixtures/same_domain_services.txt
@@ -35,7 +35,7 @@ frontend public_http_in_80
     use_backend backend_service1_80_public_http_in_80 if acl5
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/same_domain_services.txt
+++ b/service/fixtures/same_domain_services.txt
@@ -17,7 +17,7 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend http-in
+frontend public_http_in_80
     bind *:80
     mode http
     option forwardfor
@@ -29,12 +29,12 @@ frontend http-in
     acl acl3 hdr_dom(host) -i foo.com
     acl acl4 path_beg /prefix
     acl acl5 hdr_dom(host) -i foo.com
-    use_backend backend_service4_large_prefix_only_6004_public if acl1
-    use_backend backend_service4_small_prefix_only_4700_public if acl2
-    use_backend backend_service3_prefix_4700_public if acl3 acl4
-    use_backend backend_service1_80_public if acl5
+    use_backend backend_service4_large_prefix_only_6004_public_http_in_80 if acl1
+    use_backend backend_service4_small_prefix_only_4700_public_http_in_80 if acl2
+    use_backend backend_service3_prefix_4700_public_http_in_80 if acl3 acl4
+    use_backend backend_service1_80_public_http_in_80 if acl5
 
-frontend http-in-private
+frontend private_http_in_81
     bind *:81
     mode http
     option forwardfor
@@ -42,7 +42,7 @@ frontend http-in-private
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
 
-backend backend_service1_80_public
+backend backend_service1_80_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000
@@ -55,7 +55,7 @@ backend backend_service1_80_public
     server s0-192_168_35_3-7001 192.168.35.3:7001 check
     server s1-192_168_23_1-7005 192.168.23.1:7005 check
 
-backend backend_service3_prefix_4700_public
+backend backend_service3_prefix_4700_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000
@@ -64,7 +64,7 @@ backend backend_service3_prefix_4700_public
     http-response set-header X-Content-Type-Options nosniff
     server s0-192_168_35_3-7001 192.168.35.3:7001 
 
-backend backend_service4_large_prefix_only_6004_public
+backend backend_service4_large_prefix_only_6004_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000
@@ -73,7 +73,7 @@ backend backend_service4_large_prefix_only_6004_public
     http-response set-header X-Content-Type-Options nosniff
     server s0-192_168_35_33-19001 192.168.35.33:19001 
 
-backend backend_service4_small_prefix_only_4700_public
+backend backend_service4_small_prefix_only_4700_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000

--- a/service/fixtures/simple_service_2_instances.txt
+++ b/service/fixtures/simple_service_2_instances.txt
@@ -27,14 +27,6 @@ frontend public_http_in_80
     acl acl1 hdr_dom(host) -i foo.com
     use_backend backend_simple_80_public_http_in_80 if acl1
 
-frontend private_http_in_81
-    bind 10.0.0.1:81
-    mode http
-    option forwardfor
-    reqadd X-Forwarded-Port:\ %[dst_port]
-    reqadd X-Forwarded-Proto:\ https if { ssl_fc }
-    default_backend fallback
-
 backend backend_simple_80_public_http_in_80
     balance roundrobin
     mode http

--- a/service/fixtures/simple_service_2_instances.txt
+++ b/service/fixtures/simple_service_2_instances.txt
@@ -28,7 +28,7 @@ frontend public_http_in_80
     use_backend backend_simple_80_public_http_in_80 if acl1
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/simple_service_2_instances.txt
+++ b/service/fixtures/simple_service_2_instances.txt
@@ -17,7 +17,7 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend http-in
+frontend public_http_in_80
     bind *:80
     mode http
     option forwardfor
@@ -25,9 +25,9 @@ frontend http-in
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
     acl acl1 hdr_dom(host) -i foo.com
-    use_backend backend_simple_80_public if acl1
+    use_backend backend_simple_80_public_http_in_80 if acl1
 
-frontend http-in-private
+frontend private_http_in_81
     bind *:81
     mode http
     option forwardfor
@@ -35,7 +35,7 @@ frontend http-in-private
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
 
-backend backend_simple_80_public
+backend backend_simple_80_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000

--- a/service/fixtures/simple_services.txt
+++ b/service/fixtures/simple_services.txt
@@ -32,7 +32,7 @@ frontend public_http_in_80
     use_backend backend_simple2_5000_public_http_in_80 if acl3
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/simple_services.txt
+++ b/service/fixtures/simple_services.txt
@@ -17,7 +17,7 @@ defaults
     errorfile 503 /app/errors/503.http
     errorfile 504 /app/errors/504.http
 
-frontend http-in
+frontend public_http_in_80
     bind *:80
     mode http
     option forwardfor
@@ -27,11 +27,11 @@ frontend http-in
     acl acl1 path_beg /prefix
     acl acl2 hdr_dom(host) -i foo.com
     acl acl3 hdr_dom(host) -i foo2.com
-    use_backend backend_simple3_5000_public if acl1
-    use_backend backend_simple12_80_public if acl2
-    use_backend backend_simple2_5000_public if acl3
+    use_backend backend_simple3_5000_public_http_in_80 if acl1
+    use_backend backend_simple12_80_public_http_in_80 if acl2
+    use_backend backend_simple2_5000_public_http_in_80 if acl3
 
-frontend http-in-private
+frontend private_http_in_81
     bind *:81
     mode http
     option forwardfor
@@ -39,7 +39,7 @@ frontend http-in-private
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
 
-backend backend_simple12_80_public
+backend backend_simple12_80_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000
@@ -49,7 +49,7 @@ backend backend_simple12_80_public
     server s0-192_168_35_2-2345 192.168.35.2:2345 
     server s1-192_168_35_3-2346 192.168.35.3:2346 
 
-backend backend_simple2_5000_public
+backend backend_simple2_5000_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000
@@ -58,7 +58,7 @@ backend backend_simple2_5000_public
     http-response set-header X-Content-Type-Options nosniff
     server s0-192_168_35_3-7001 192.168.35.3:7001 
 
-backend backend_simple3_5000_public
+backend backend_simple3_5000_public_http_in_80
     balance roundrobin
     mode http
     http-response set-header Strict-Transport-Security max-age=63072000

--- a/service/fixtures/ssh_gogs.txt
+++ b/service/fixtures/ssh_gogs.txt
@@ -24,8 +24,6 @@ frontend public_http_in_80
     reqadd X-Forwarded-Port:\ %[dst_port]
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
-    acl acl1 hdr_dom(host) -i foo.com
-    use_backend backend_sticky1_80_public_http_in_80 if acl1
 
 frontend private_http_in_81
     bind *:81
@@ -35,13 +33,16 @@ frontend private_http_in_81
     reqadd X-Forwarded-Proto:\ https if { ssl_fc }
     default_backend fallback
 
-backend backend_sticky1_80_public_http_in_80
+frontend public_tcp_in_8022
+    bind *:8022
+    mode tcp
+    default_backend fallback
+    acl acl1 true
+    use_backend backend_gogs_22_public_tcp_in_8022 if acl1
+
+backend backend_gogs_22_public_tcp_in_8022
     balance source
-    mode http
-    http-response set-header Strict-Transport-Security max-age=63072000
-    http-response set-header X-Frame-Option SAMEORIGIN
-    http-response set-header X-XSS-Protection 1;mode=block
-    http-response set-header X-Content-Type-Options nosniff
+    mode tcp
     server s0-192_168_35_2-2345 192.168.35.2:2345 
     server s1-192_168_35_3-2346 192.168.35.3:2346 
     server s2-192_168_23_32-2346 192.168.23.32:2346 

--- a/service/fixtures/ssh_gogs.txt
+++ b/service/fixtures/ssh_gogs.txt
@@ -26,7 +26,7 @@ frontend public_http_in_80
     default_backend fallback
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/fixtures/sticky_service.txt
+++ b/service/fixtures/sticky_service.txt
@@ -28,7 +28,7 @@ frontend public_http_in_80
     use_backend backend_sticky1_80_public_http_in_80 if acl1
 
 frontend private_http_in_81
-    bind *:81
+    bind 10.0.0.1:81
     mode http
     option forwardfor
     reqadd X-Forwarded-Port:\ %[dst_port]

--- a/service/service.go
+++ b/service/service.go
@@ -51,6 +51,8 @@ type ServiceConfig struct {
 	PrivateHost       string
 	PublicHost        string
 	PrivateTcpSslCert string // Name of SSL certificate used for private tcp connections
+	ExcludePublic     bool   // If set, all public frontends are excluded
+	ExcludePrivate    bool   // If set, all private frontends are excluded
 }
 
 type ServiceDependencies struct {

--- a/service/service.go
+++ b/service/service.go
@@ -49,6 +49,7 @@ type ServiceConfig struct {
 	SslCertsFolder    string
 	ForceSsl          bool
 	PrivateHost       string
+	PublicHost        string
 	PrivateTcpSslCert string // Name of SSL certificate used for private tcp connections
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -189,6 +189,11 @@ func (s *Service) createConfigFile() (string, string, error) {
 		return "", "", maskAny(err)
 	}
 
+	// Normalize services
+	for i, s := range services {
+		services[i] = s.Normalize()
+	}
+
 	// Sort the services
 	services.Sort()
 


### PR DESCRIPTION
Added support for a variable number of frontends.
With a new `frontend-port` field in the ETCD frontend registration, you can specify the port on the host that robin will listen on for a (set of) service(s).

This can be used in combination with the `mode` flag. It is now possible to listen on some port (e.g. 4566) and forward all incoming requests on that port in TCP mode to a set of servers.
